### PR TITLE
Fix crash when there are no gamepads

### DIFF
--- a/src/main/java/com/mrcrayfish/controllable/client/gui/GuiControllerSelection.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/gui/GuiControllerSelection.java
@@ -60,7 +60,7 @@ public class GuiControllerSelection extends GuiScreen
         if(!button.enabled)
             return;
 
-        if(button.id == 0)
+        if(button.id == 0 && listControllers.getSelectedIndex() > -1)
         {
             ControllerIndex index = manager.getControllerIndex(listControllers.getSelectedIndex());
             Controller controller = new Controller(index);


### PR DESCRIPTION
I got the following stack trace when clicking "Select" when there are no gamepads listed:
```
java.lang.ArrayIndexOutOfBoundsException: -1
	at com.studiohartman.jamepad.ControllerManager.getControllerIndex(ControllerManager.java:237)
	at com.mrcrayfish.controllable.client.gui.GuiControllerSelection.func_146284_a(GuiControllerSelection.java:65)
	at net.minecraft.client.gui.GuiScreen.func_73864_a(GuiScreen.java:443)
	at com.mrcrayfish.controllable.client.gui.GuiControllerSelection.func_73864_a(GuiControllerSelection.java:109)
	at net.minecraft.client.gui.GuiScreen.func_146274_d(GuiScreen.java:533)
	at com.mrcrayfish.controllable.client.gui.GuiControllerSelection.func_146274_d(GuiControllerSelection.java:102)
	at net.minecraft.client.gui.GuiScreen.func_146269_k(GuiScreen.java:501)
```