### PR TITLE
Add optional async polling of button states

### DIFF
--- a/src/main/java/com/mrcrayfish/controllable/ButtonStateTracker.java
+++ b/src/main/java/com/mrcrayfish/controllable/ButtonStateTracker.java
@@ -1,0 +1,58 @@
+package com.mrcrayfish.controllable;
+
+import com.mrcrayfish.controllable.client.Buttons;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+public class ButtonStateTracker
+{
+    private ButtonStates lastState;
+    private final ConcurrentLinkedDeque<ButtonStateChange> stateChanges;
+
+    public ButtonStateTracker(ButtonStates initialState)
+    {
+        this.lastState = initialState;
+        this.stateChanges = new ConcurrentLinkedDeque<>();
+    }
+
+    /**
+     * The given new state will be compared against the state from the previous
+     * call to this method, and any state changes will be noted.
+     */
+    public synchronized ButtonStateTracker update(ButtonStates newState)
+    {
+        for(int button : Buttons.BUTTONS)
+        {
+            boolean oldPressed = lastState.getState(button);
+            boolean newPressed = newState.getState(button);
+            if(oldPressed != newPressed)
+            {
+                stateChanges.add(new ButtonStateChange(button, newPressed));
+            }
+        }
+        lastState = newState;
+        return this;
+    }
+
+    public ButtonStateChange poll()
+    {
+        return stateChanges.poll();
+    }
+
+    public ButtonStates getLastState()
+    {
+        return lastState;
+    }
+
+    public static class ButtonStateChange
+    {
+        public final int button;
+        public final boolean state;
+
+        public ButtonStateChange(int button, boolean state)
+        {
+            this.button = button;
+            this.state = state;
+        }
+    }
+}

--- a/src/main/java/com/mrcrayfish/controllable/ButtonStates.java
+++ b/src/main/java/com/mrcrayfish/controllable/ButtonStates.java
@@ -21,7 +21,7 @@ public class ButtonStates
         return this.states[index];
     }
 
-    protected void setState(int index, boolean state)
+    public void setState(int index, boolean state)
     {
         if(index < 0 || index >= states.length)
             return;

--- a/src/main/java/com/mrcrayfish/controllable/Config.java
+++ b/src/main/java/com/mrcrayfish/controllable/Config.java
@@ -51,6 +51,7 @@ public class Config
             public final ForgeConfigSpec.EnumValue<SneakMode> sneakMode;
             public final ForgeConfigSpec.EnumValue<Thumbstick> cursorThumbstick;
             public final ForgeConfigSpec.DoubleValue hoverModifier;
+            public final ForgeConfigSpec.BooleanValue asyncPolling;
 
             public Options(ForgeConfigSpec.Builder builder)
             {
@@ -74,6 +75,7 @@ public class Config
                     this.sneakMode = builder.comment("The behaviour to use for sneaking. Toggle means to press once to sneak then press again to stand again. Hold means you must hold the sneak button and releasing will make the player stand again.").translation("controllable.config.sneakMode").defineEnum("sneakMode", SneakMode.TOGGLE);
                     this.cursorThumbstick = builder.comment("The thumbstick that controls moving the cursor").translation("controllable.config.cursorThumbstick").defineEnum("cursorThumbstick", Thumbstick.LEFT);
                     this.hoverModifier = builder.comment("The scale of the mouse speed when hovering a widget or item slot").defineInRange("hoverModifier", 0.6, 0.05, 1.0);
+                    this.asyncPolling = builder.comment("If enabled, the controller inputs will be polled in a background thread instead of the main thread. This can be more responsive at low framerates.").define("asyncPolling", false);
                 }
                 builder.pop();
             }

--- a/src/main/java/com/mrcrayfish/controllable/client/Controller.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/Controller.java
@@ -1,6 +1,8 @@
 package com.mrcrayfish.controllable.client;
 
+import com.google.common.base.Preconditions;
 import com.mrcrayfish.controllable.ButtonStates;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWGamepadState;
@@ -51,6 +53,8 @@ public class Controller
      */
     public boolean updateGamepadState()
     {
+        Preconditions.checkState(Minecraft.getInstance().isOnExecutionThread(),
+                "updateGamepadState should only be called from the main thread");
         return GLFW.glfwGetGamepadState(this.jid, this.controller);
     }
 

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllerManager.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllerManager.java
@@ -1,5 +1,7 @@
 package com.mrcrayfish.controllable.client;
 
+import com.google.common.base.Preconditions;
+import net.minecraft.client.Minecraft;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.HashMap;
@@ -17,6 +19,8 @@ public class ControllerManager
 
     public void update()
     {
+        Preconditions.checkState(Minecraft.getInstance().isOnExecutionThread(),
+                "update must be called from the main thread");
         int connectedCount = 0;
         for(int jid = GLFW.GLFW_JOYSTICK_1; jid <= GLFW.GLFW_JOYSTICK_LAST; jid++)
         {

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
@@ -1,0 +1,113 @@
+package com.mrcrayfish.controllable.client;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.mrcrayfish.controllable.ButtonStateTracker;
+import com.mrcrayfish.controllable.ButtonStates;
+import com.mrcrayfish.controllable.Controllable;
+import org.lwjgl.glfw.GLFW;
+
+import javax.annotation.Nullable;
+import java.util.WeakHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ControllerPoller
+{
+    /**
+     * Rate of controller polling, in hertz (i.e. per-second)
+     * Common controller poll rates:
+     * - Xbox One: 125Hz
+     * - PS4 DualShock 4: 250Hz (USB) / 500Hz (Bluetooth)
+     * https://forums.guru3d.com/threads/anybody-know-what-polling-rate-xbox-controllers-use-on-windows-10.422404/
+     */
+    private static final int POLL_RATE_HZ = 125;
+
+    private final ControllerManager manager;
+    private final WeakHashMap<Controller, ButtonStateTracker> stateTrackers;
+    private ScheduledExecutorService executor;
+
+    public ControllerPoller(ControllerManager manager)
+    {
+        this.manager = manager;
+        this.stateTrackers = new WeakHashMap<>(4);
+    }
+
+    public boolean isAsyncPollingEnabled()
+    {
+        return ControllerProperties.isAsyncPollingEnabled();
+    }
+
+    public void startAsyncPolling()
+    {
+        if(!isAsyncPollingEnabled() || this.executor != null)
+        {
+            return;
+        }
+
+        this.executor = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("Controllable-Poller-%d").setDaemon(true).build());
+        // by using daemon threads, we don't have to worry about cleanup during exit
+
+        // TODO the poll rate should be configurable
+        executor.scheduleAtFixedRate(this::poll, 0, 1000000000L / POLL_RATE_HZ, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Poll will call the ControllerManager to update the list of controllers, and then
+     * assuming a controller is connected, will update the state of that controller.
+     * If async polling is enabled, this method will be called from a background thread;
+     * it can be called multiple times before the client tick loop will retrieve the
+     * states that were found from polling.
+     */
+    public void poll()
+    {
+        manager.update();
+        Controller controller = Controllable.getController();
+        if(controller != null)
+        {
+            controller.updateGamepadState();
+            gatherAndQueueControllerInput(controller);
+        }
+    }
+
+    private void gatherAndQueueControllerInput(Controller controller)
+    {
+        ButtonStates states = new ButtonStates();
+        states.setState(Buttons.A, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_A, controller));
+        states.setState(Buttons.B, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_B, controller));
+        states.setState(Buttons.X, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_X, controller));
+        states.setState(Buttons.Y, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_Y, controller));
+        states.setState(Buttons.SELECT, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_BACK, controller));
+        states.setState(Buttons.HOME, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_GUIDE, controller));
+        states.setState(Buttons.START, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_START, controller));
+        states.setState(Buttons.LEFT_THUMB_STICK, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_LEFT_THUMB, controller));
+        states.setState(Buttons.RIGHT_THUMB_STICK, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_RIGHT_THUMB, controller));
+        states.setState(Buttons.LEFT_BUMPER, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_LEFT_BUMPER, controller));
+        states.setState(Buttons.RIGHT_BUMPER, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER, controller));
+        states.setState(Buttons.LEFT_TRIGGER, controller.getLTriggerValue() >= 0.5F);
+        states.setState(Buttons.RIGHT_TRIGGER, controller.getRTriggerValue() >= 0.5F);
+        states.setState(Buttons.DPAD_UP, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_DPAD_UP, controller));
+        states.setState(Buttons.DPAD_DOWN, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_DPAD_DOWN, controller));
+        states.setState(Buttons.DPAD_LEFT, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_DPAD_LEFT, controller));
+        states.setState(Buttons.DPAD_RIGHT, getButtonState(GLFW.GLFW_GAMEPAD_BUTTON_DPAD_RIGHT, controller));
+
+        stateTrackers.compute(controller, (k, tracker) ->
+                tracker == null ? new ButtonStateTracker(states) : tracker.update(states));
+    }
+
+    private static boolean getButtonState(int buttonCode, Controller controller)
+    {
+        return controller != null && controller.getGamepadState().buttons(buttonCode) == GLFW.GLFW_PRESS;
+    }
+
+    @Nullable
+    public ButtonStateTracker getStateTracker(Controller controller)
+    {
+        if(controller == null)
+        {
+            return null;
+        }
+        return stateTrackers.get(controller);
+    }
+}

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
@@ -63,6 +63,10 @@ public class ControllerPoller
      */
     public void poll()
     {
+        if(!Minecraft.getInstance().isRunning())
+        {
+            return;
+        }
         Minecraft.getInstance().enqueue(() ->
         {
             manager.update();

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
@@ -92,7 +92,7 @@ public class ControllerPoller
         {
             return;
         }
-        Minecraft.getInstance().enqueue(() ->
+        Minecraft.getInstance().execute(() ->
         {
             manager.update();
             Controller controller = Controllable.getController();

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllerPoller.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.mrcrayfish.controllable.ButtonStateTracker;
 import com.mrcrayfish.controllable.ButtonStates;
 import com.mrcrayfish.controllable.Controllable;
+import net.minecraft.client.Minecraft;
 import org.lwjgl.glfw.GLFW;
 
 import javax.annotation.Nullable;
@@ -62,13 +63,18 @@ public class ControllerPoller
      */
     public void poll()
     {
-        manager.update();
-        Controller controller = Controllable.getController();
-        if(controller != null)
+        Minecraft.getInstance().enqueue(() ->
         {
-            controller.updateGamepadState();
-            gatherAndQueueControllerInput(controller);
-        }
+            manager.update();
+            Controller controller = Controllable.getController();
+            if(controller != null)
+            {
+                if(controller.updateGamepadState())
+                {
+                    gatherAndQueueControllerInput(controller);
+                }
+            }
+        });
     }
 
     private void gatherAndQueueControllerInput(Controller controller)

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllerProperties.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllerProperties.java
@@ -18,10 +18,6 @@ public class ControllerProperties
     private static String lastController = "";
     private static String selectedMapping = "";
 
-    // TODO add async poll rate Hz setting
-    // TODO move the async settings into ControllerOptions
-    private static Boolean asyncPolling = null;
-
     public static void load(File configFolder)
     {
         if(!loaded)
@@ -41,8 +37,6 @@ public class ControllerProperties
                         properties.load(is);
                         lastController = properties.getProperty("CurrentController", "");
                         selectedMapping = properties.getProperty("SelectedMapping", "");
-                        String asyncPollingStr = properties.getProperty("AsyncPolling");
-                        asyncPolling = asyncPollingStr == null ? null : Boolean.parseBoolean(asyncPollingStr);
                     }
                 }
             }
@@ -62,13 +56,6 @@ public class ControllerProperties
         Properties properties = new Properties();
         properties.setProperty("LastController", lastController);
         properties.setProperty("SelectedMapping", selectedMapping);
-
-        // Only write the AsyncPolling setting to file if it is set; this way we can change the default after it's
-        // determined to be stable, and existing users who upgrade won't be stuck at the old setting.
-        if(asyncPolling != null)
-        {
-            properties.setProperty("AsyncPolling", asyncPolling.toString());
-        }
 
         try
         {
@@ -98,11 +85,5 @@ public class ControllerProperties
     public static void setSelectedMapping(String selectedMapping)
     {
         ControllerProperties.selectedMapping = selectedMapping;
-    }
-
-    public static boolean isAsyncPollingEnabled()
-    {
-        // (default off if null)
-        return Boolean.TRUE.equals(asyncPolling);
     }
 }

--- a/src/main/java/com/mrcrayfish/controllable/client/ControllerProperties.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/ControllerProperties.java
@@ -18,6 +18,10 @@ public class ControllerProperties
     private static String lastController = "";
     private static String selectedMapping = "";
 
+    // TODO add async poll rate Hz setting
+    // TODO move the async settings into ControllerOptions
+    private static Boolean asyncPolling = null;
+
     public static void load(File configFolder)
     {
         if(!loaded)
@@ -37,6 +41,8 @@ public class ControllerProperties
                         properties.load(is);
                         lastController = properties.getProperty("CurrentController", "");
                         selectedMapping = properties.getProperty("SelectedMapping", "");
+                        String asyncPollingStr = properties.getProperty("AsyncPolling");
+                        asyncPolling = asyncPollingStr == null ? null : Boolean.parseBoolean(asyncPollingStr);
                     }
                 }
             }
@@ -56,6 +62,14 @@ public class ControllerProperties
         Properties properties = new Properties();
         properties.setProperty("LastController", lastController);
         properties.setProperty("SelectedMapping", selectedMapping);
+
+        // Only write the AsyncPolling setting to file if it is set; this way we can change the default after it's
+        // determined to be stable, and existing users who upgrade won't be stuck at the old setting.
+        if(asyncPolling != null)
+        {
+            properties.setProperty("AsyncPolling", asyncPolling.toString());
+        }
+
         try
         {
             properties.store(new FileOutputStream(file), "Controller Properties");
@@ -84,5 +98,11 @@ public class ControllerProperties
     public static void setSelectedMapping(String selectedMapping)
     {
         ControllerProperties.selectedMapping = selectedMapping;
+    }
+
+    public static boolean isAsyncPollingEnabled()
+    {
+        // (default off if null)
+        return Boolean.TRUE.equals(asyncPolling);
     }
 }

--- a/src/main/java/com/mrcrayfish/controllable/client/gui/ControllerLayoutScreen.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/gui/ControllerLayoutScreen.java
@@ -277,10 +277,8 @@ public class ControllerLayoutScreen extends Screen
         }
     }
 
-    public void processButton(int index, ButtonStates newStates)
+    public void processButton(int index, boolean state)
     {
-        boolean state = newStates.getState(index);
-
         if(state && this.onButtonInput(index))
         {
             return;

--- a/src/main/java/com/mrcrayfish/controllable/client/gui/SettingsScreen.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/gui/SettingsScreen.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  */
 public class SettingsScreen extends ListMenuScreen
 {
-    private static final AbstractOption[] OPTIONS = new AbstractOption[]{ControllerOptions.AUTO_SELECT, ControllerOptions.RENDER_MINI_PLAYER, ControllerOptions.VIRTUAL_MOUSE, ControllerOptions.CONSOLE_HOTBAR, ControllerOptions.CONTROLLER_ICONS, ControllerOptions.CURSOR_TYPE, ControllerOptions.INVERT_LOOK, ControllerOptions.DEAD_ZONE, ControllerOptions.ROTATION_SPEED, ControllerOptions.MOUSE_SPEED, ControllerOptions.SHOW_ACTIONS, ControllerOptions.QUICK_CRAFT, ControllerOptions.UI_SOUNDS, ControllerOptions.RADIAL_THUMBSTICK, ControllerOptions.SNEAK_MODE, ControllerOptions.CURSOR_THUMBSTICK, ControllerOptions.HOVER_MODIFIER};
+    private static final AbstractOption[] OPTIONS = new AbstractOption[]{ControllerOptions.AUTO_SELECT, ControllerOptions.RENDER_MINI_PLAYER, ControllerOptions.VIRTUAL_MOUSE, ControllerOptions.CONSOLE_HOTBAR, ControllerOptions.CONTROLLER_ICONS, ControllerOptions.CURSOR_TYPE, ControllerOptions.INVERT_LOOK, ControllerOptions.DEAD_ZONE, ControllerOptions.ROTATION_SPEED, ControllerOptions.MOUSE_SPEED, ControllerOptions.SHOW_ACTIONS, ControllerOptions.QUICK_CRAFT, ControllerOptions.UI_SOUNDS, ControllerOptions.RADIAL_THUMBSTICK, ControllerOptions.SNEAK_MODE, ControllerOptions.CURSOR_THUMBSTICK, ControllerOptions.HOVER_MODIFIER, ControllerOptions.ASYNC_POLLING};
     private IToolTip hoveredTooltip;
     private int hoveredCounter;
 

--- a/src/main/java/com/mrcrayfish/controllable/client/settings/ControllerOptions.java
+++ b/src/main/java/com/mrcrayfish/controllable/client/settings/ControllerOptions.java
@@ -171,4 +171,11 @@ public class ControllerOptions
         double mouseSpeed = Config.CLIENT.options.hoverModifier.get();
         return new TranslationTextComponent("controllable.options.hoverModifier.format", FORMAT.format(mouseSpeed));
     });
+
+    public static final BooleanOption ASYNC_POLLING = new ControllableBooleanOption("controllable.options.asyncPolling", gameSettings -> {
+        return Config.CLIENT.options.asyncPolling.get();
+    }, (gameSettings, value) -> {
+        Config.CLIENT.options.asyncPolling.set(value);
+        Config.save();
+    });
 }

--- a/src/main/resources/assets/controllable/lang/en_gb.json
+++ b/src/main/resources/assets/controllable/lang/en_gb.json
@@ -78,6 +78,8 @@
     "controllable.options.virtualMouse.desc": "If enabled, the game will use a virtual cursor instead of the real cursor. This must be turned on to be able to run multiple instances!",
     "controllable.options.consoleHotbar": "Console Hotbar",
     "controllable.options.consoleHotbar.desc": "If enabled, hotbar will render closer to the center of the screen like on console.",
+    "controllable.options.asyncPolling": "Async Polling Enabled",
+    "controllable.options.asyncPolling.desc": "If enabled, the controller inputs will be polled in a background thread instead of the main thread. This can be more responsive at low framerates.",
     "controllable.options.cursorType": "Cursor Type",
     "controllable.options.cursorType.desc": "The image to use for the cursor. This only applies if virtual mouse is enabled!",
     "controllable.options.cursorType.format": "Cursor Type: %s",

--- a/src/main/resources/assets/controllable/lang/en_us.json
+++ b/src/main/resources/assets/controllable/lang/en_us.json
@@ -82,6 +82,8 @@
     "controllable.options.virtualMouse.desc": "If enabled, the game will use a virtual cursor instead of the real cursor. This must be turned on to be able to run multiple instances!",
     "controllable.options.consoleHotbar": "Console Hotbar",
     "controllable.options.consoleHotbar.desc": "If enabled, hotbar will render closer to the center of the screen like on console.",
+    "controllable.options.asyncPolling": "Async Polling Enabled",
+    "controllable.options.asyncPolling.desc": "If enabled, the controller inputs will be polled in a background thread instead of the main thread. This can be more responsive at low framerates.",
     "controllable.options.cursorType": "Cursor Type",
     "controllable.options.cursorType.desc": "The image to use for the cursor. This only applies if virtual mouse is enabled!",
     "controllable.options.cursorType.format": "Cursor Type: %s",


### PR DESCRIPTION
(in progress -- builds & tested; see todo list below)

Today Controllable checks button states in the client tick, which appears to be tied to the framerate. So if you have a framerate limit set to 30 or 40 fps, then it's easy to rapidly press a button where Controllable won't notice that you released & pressed it. For example, if you rapidly press R1, the number of hotbar slot changes is often less than the number of button presses. You can repro this _very_ reliably by reducing framerate limit as low as 10 or 20.

Per discussion in #344 , GLFW doesn't support callback-based gamepad button events, so we have to poll. Which means to fix this issue, we need a background thread that can poll at a higher rate; 125Hz is a common polling rate for peripherals so I think we should aim for at least that.

I started by refactoring the controller button state polling, separate from the button handling. Then added a toggle for whether to do the polling async (in its own thread) or to do it in the client tick like today. If async, then a ScheduledExecutorService is used to trigger the polling at a fixed rate. The polling side is only GLFW calls, nothing touching Minecraft at all, so it should be ok on a background thread.

The poll makes a new `ButtonStates`, compares it to the previous and adds any new button presses/releases to a thread-safe queue of button state events. Then, the client tick handler consumes the entries in the queue and handles each one as a button state change.

Test plan:
* Video settings > Framerate limit set to 10 or 20.
* Rapid press L1 or R1, see if it always moves the correct number of hotbar slots.
* Rapid press swap hands button, see that it always swaps the correct number of times
* Rapid press camera change button, see that it always changes camera
* I expect inventory navigation should feel more responsive too
* Button binding should still work
* Radial menu should still work

Todo:

- [ ] @MrCrayfish should the default for this feature be on or off? Or should we only do async polling and not even give the option?
- [x] Add config GUI setting for polling frequency, and move the async enabled into the config GUI too.
- [x] Thoroughly test to make sure there's no issues.

Out of scope for this PR, a follow-up change could be made to separate out the events that don't need to wait for the client tick. For example, buttons that move the mouse around, should be able to be processed immediately (or at least queued for immediate execution on the main thread). So that those can benefit from 125Hz or the video frame rate, and not be stuck processing these at 20Hz. Or the events which have to send a packet to the server and wait for the response, can kick that packet off sooner and thus feel quicker.

Fixes #344 