### PR TITLE
🐛 Fixed crash with OptiFine

### DIFF
--- a/Forge/src/main/java/com/mrcrayfish/controllable/mixin/ControllableMixinPlugin.java
+++ b/Forge/src/main/java/com/mrcrayfish/controllable/mixin/ControllableMixinPlugin.java
@@ -36,7 +36,14 @@ public class ControllableMixinPlugin implements IMixinConfigPlugin
         {
             return false;
         }
-        return this.optifineLoaded ? !mixinClassName.equals("com.mrcrayfish.controllable.mixin.client.GameRendererMixin") : !mixinClassName.equals("com.mrcrayfish.controllable.mixin.client.OptifineGameRendererMixin");
+        if(this.optifineLoaded)
+        {
+            if(mixinClassName.equals("com.mrcrayfish.controllable.mixin.client.GameRendererMixin") || mixinClassName.equals("com.mrcrayfish.controllable.mixin.client.ForgeGameRendererMixin"))
+            {
+                return false;
+            }
+        }
+        return !mixinClassName.equals("com.mrcrayfish.controllable.mixin.client.OptifineGameRendererMixin");
     }
 
     @Override

--- a/Forge/src/main/java/com/mrcrayfish/controllable/mixin/ControllableMixinPlugin.java
+++ b/Forge/src/main/java/com/mrcrayfish/controllable/mixin/ControllableMixinPlugin.java
@@ -42,6 +42,7 @@ public class ControllableMixinPlugin implements IMixinConfigPlugin
             {
                 return false;
             }
+            return true;
         }
         return !mixinClassName.equals("com.mrcrayfish.controllable.mixin.client.OptifineGameRendererMixin");
     }

--- a/Forge/src/main/java/com/mrcrayfish/controllable/mixin/client/OptifineGameRendererMixin.java
+++ b/Forge/src/main/java/com/mrcrayfish/controllable/mixin/client/OptifineGameRendererMixin.java
@@ -1,13 +1,21 @@
 package com.mrcrayfish.controllable.mixin.client;
 
+import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.vertex.PoseStack;
 import com.mrcrayfish.controllable.Config;
 import com.mrcrayfish.controllable.Controllable;
 import com.mrcrayfish.controllable.client.ControllerInput;
+import com.mrcrayfish.controllable.client.OverlayHandler;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.GameRenderer;
+import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 /**
  * Author: MrCrayfish
@@ -32,5 +40,12 @@ public class OptifineGameRendererMixin
             args[3] = mouseY;
         }
         return args;
+    }
+
+    @SuppressWarnings("InvalidInjectorMethodSignature")
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;flush()V"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void controllableLastRender(float partialTick, long p_109095_, boolean running, CallbackInfo ci, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f matrix4f, PoseStack posestack, float guiOffsetZ, GuiGraphics graphics)
+    {
+        OverlayHandler.draw(graphics, mouseX, mouseY, partialTick);
     }
 }


### PR DESCRIPTION
The cause of the crash was when trying to inject the "controllableLastRender" method, it was looking for a specific set of arguments while without OptiFine it worked, but with it, it would crash. This is because in OptiFine it adds two new fields inside the render method. Seen below:

```diff
@@ -899,24 +1041,33 @@
                RenderSystem.disableBlend();
                RenderSystem.disableDepthTest();
                RenderSystem.resetTextureMatrix();
                this.postEffect.process(p_109094_);
+               RenderSystem.enableTexture();
             }
 
             this.minecraft.getMainRenderTarget().bindWrite(true);
+         } else {
+            RenderSystem.viewport(0, 0, this.minecraft.getWindow().getWidth(), this.minecraft.getWindow().getHeight());
          }
 
          Window window = this.minecraft.getWindow();
          RenderSystem.clear(256, Minecraft.ON_OSX);
-         Matrix4f matrix4f = (new Matrix4f()).setOrtho(0.0F, (float)((double)window.getWidth() / window.getGuiScale()), (float)((double)window.getHeight() / window.getGuiScale()), 0.0F, 1000.0F, 21000.0F);
+         float guiFarPlane = Reflector.ForgeHooksClient_getGuiFarPlane.exists() ? Reflector.ForgeHooksClient_getGuiFarPlane.callFloat() : 21000.0F; // optifine
+         Matrix4f matrix4f = (new Matrix4f()).setOrtho(0.0F, (float)((double)window.getWidth() / window.getGuiScale()), (float)((double)window.getHeight() / window.getGuiScale()), 0.0F, 1000.0F, guiFarPlane);
          RenderSystem.setProjectionMatrix(matrix4f, VertexSorting.ORTHOGRAPHIC_Z);
          PoseStack posestack = RenderSystem.getModelViewStack();
          posestack.pushPose();
          posestack.setIdentity();
-         posestack.translate(0.0F, 0.0F, -11000.0F);
+         float guiOffsetZ = Reflector.ForgeHooksClient_getGuiFarPlane.exists() ? 1000.0F - guiFarPlane : -11000.0F;
+         posestack.translate(0.0, 0.0, guiOffsetZ); // optifine
          RenderSystem.applyModelViewMatrix();
          Lighting.setupFor3DItems();
          GuiGraphics guigraphics = new GuiGraphics(this.minecraft, this.renderBuffers.bufferSource());
+         if (this.lightTexture.isCustom()) {
+            this.lightTexture.setAllowed(false);
+         }
+
          if (p_109096_ && this.minecraft.level != null) {
             this.minecraft.getProfiler().popPush("gui");
             if (this.minecraft.player != null) {
                float f = Mth.lerp(p_109094_, this.minecraft.player.oSpinningEffectIntensity, this.minecraft.player.spinningEffectIntensity);
```

![image](https://github.com/MrCrayfish/Controllable/assets/60985521/8fbfe2ef-2b77-4ebc-81fa-e54e513e1531)

Fixes #433, fixes #418, fixes #472, fixes #477