### PR TITLE
Disable jei support if emi is loaded

### DIFF
--- a/Fabric/src/main/java/com/mrcrayfish/controllable/platform/FabricClientHelper.java
+++ b/Fabric/src/main/java/com/mrcrayfish/controllable/platform/FabricClientHelper.java
@@ -91,7 +91,7 @@ public class FabricClientHelper implements IClientHelper
     @Override
     public List<NavigationPoint> getJeiNavigationPoints()
     {
-        if(!FabricLoader.getInstance().isModLoaded("jei"))
+        if(!FabricLoader.getInstance().isModLoaded("jei") || FabricLoader.getInstance().isModLoaded("emi"))
             return Collections.emptyList();
         return JeiSupport.getNavigationPoints();
     }

--- a/Forge/src/main/java/com/mrcrayfish/controllable/platform/ForgeClientHelper.java
+++ b/Forge/src/main/java/com/mrcrayfish/controllable/platform/ForgeClientHelper.java
@@ -139,8 +139,9 @@ public class ForgeClientHelper implements IClientHelper
     @Override
     public List<NavigationPoint> getJeiNavigationPoints()
     {
-        if(!ModList.get().isLoaded("jei"))
+        if(!ModList.get().isLoaded("jei") || ModList.get().isLoaded("emi")) {
             return Collections.emptyList();
+        }
         return JeiSupport.getNavigationPoints();
     }
 

--- a/Forge/src/main/java/com/mrcrayfish/controllable/platform/ForgeClientHelper.java
+++ b/Forge/src/main/java/com/mrcrayfish/controllable/platform/ForgeClientHelper.java
@@ -139,9 +139,8 @@ public class ForgeClientHelper implements IClientHelper
     @Override
     public List<NavigationPoint> getJeiNavigationPoints()
     {
-        if(!ModList.get().isLoaded("jei") || ModList.get().isLoaded("emi")) {
+        if(!ModList.get().isLoaded("jei") || ModList.get().isLoaded("emi"))
             return Collections.emptyList();
-        }
         return JeiSupport.getNavigationPoints();
     }
 


### PR DESCRIPTION
When emi is loaded it replaces the jei UI, causing a crash when the player uses the dpad in the inventory (and other menus). This fixes the crash by disabling jei support if emi is also loaded.

Fixes various issues (likely others, not an exhaustive list, just the ones that showed the exact same error I encountered)

- #531
- #529 
- #527 
- #474 