### PR TITLE
Added setting Controller Index for selecting a specific controller by default

### DIFF
--- a/common/src/main/java/com/mrcrayfish/controllable/Config.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/Config.java
@@ -47,6 +47,9 @@ public class Config
             @ConfigProperty(name = "autoSelect", comment = "If enabled, controller will be automatically selected on start up or when plugged in")
             public final BoolProperty autoSelect = BoolProperty.create(true);
 
+            @ConfigProperty(name = "autoSelectIndex", comment = "The index of the controller to auto-select (-1 for first available)")
+            public final DoubleProperty autoSelectIndex = DoubleProperty.create(-1.0, -1.0, 10.0);
+
             @ConfigProperty(name = "renderMiniPlayer", comment = "If enabled, the player will render in the top left corner likes Bedrock Edition")
             public final BoolProperty renderMiniPlayer = BoolProperty.create(true);
 

--- a/common/src/main/java/com/mrcrayfish/controllable/client/gui/screens/SettingsScreen.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/client/gui/screens/SettingsScreen.java
@@ -304,6 +304,7 @@ public class SettingsScreen extends Screen
             // Controller options
             optionsList.addEntry(new TabOptionTitleItem(Component.translatable("controllable.gui.title.controller").withStyle(ChatFormatting.BOLD, ChatFormatting.YELLOW)));
             optionsList.addEntry(new TabOptionToggleItem(Config.CLIENT.client.options.autoSelect));
+            optionsList.addEntry(new TabOptionSliderItem(Config.CLIENT.client.options.autoSelectIndex, 1.0));
             optionsList.addEntry(new TabOptionToggleItem(Config.CLIENT.client.options.virtualCursor));
             optionsList.addEntry(new TabOptionSliderItem(Config.CLIENT.client.options.thumbstickDeadZone, 0.01));
             optionsList.addEntry(new TabOptionSliderItem(Config.CLIENT.client.options.triggerDeadZone, 0.01));

--- a/common/src/main/java/com/mrcrayfish/controllable/client/input/ControllerManager.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/client/input/ControllerManager.java
@@ -71,7 +71,23 @@ public abstract class ControllerManager
 
         if(controller == null && Config.CLIENT.client.options.autoSelect.get())
         {
-            controller = this.connectToFirstGameController();
+            double targetIndex = Config.CLIENT.client.options.autoSelectIndex.get();
+            if(targetIndex < 0) {
+                controller = this.connectToFirstGameController();
+            } else {
+                // Try to connect to the specified index
+                for(Map.Entry<Number, Pair<Integer, String>> entry : this.controllers.entrySet()) {
+                    if(entry.getValue().getLeft() == (int)targetIndex) {
+                        controller = this.createController(entry.getValue().getLeft(), entry.getKey());
+                        if(controller != null && this.setActiveController(controller)) {
+                            break;
+                        }
+                    }
+                }
+                if(controller == null) {
+                    Constants.LOG.warn("Could not connect to controller at index {}", (int)targetIndex);
+                }
+            }
             this.sendControllerToast(true, controller);
         }
     }
@@ -155,7 +171,21 @@ public abstract class ControllerManager
         /* Attempts to load the first game controller connected if auto select is enabled */
         if(Config.CLIENT.client.options.autoSelect.get())
         {
-            this.connectToFirstGameController();
+            double targetIndex = Config.CLIENT.client.options.autoSelectIndex.get();
+            if(targetIndex < 0) {
+                this.connectToFirstGameController();
+            } else {
+                // Try to connect to the specified index
+                for(Map.Entry<Number, Pair<Integer, String>> entry : this.controllers.entrySet()) {
+                    if(entry.getValue().getLeft() == (int)targetIndex) {
+                        Controller controller = this.createController(entry.getValue().getLeft(), entry.getKey());
+                        if(controller != null && this.setActiveController(controller)) {
+                            this.sendControllerToast(true, controller);
+                            break;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/common/src/main/java/com/mrcrayfish/controllable/client/settings/ControllerOptions.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/client/settings/ControllerOptions.java
@@ -29,6 +29,7 @@ public class ControllerOptions
     });*/
 
     public static final ControllerSetting<Boolean> AUTO_SELECT = createToggleSetting("controllable.options.autoSelect", Config.CLIENT.client.options.autoSelect);
+    public static final ControllerSetting<Double> AUTO_SELECT_INDEX = createSliderSetting("controllable.options.autoSelectIndex", Config.CLIENT.client.options.autoSelectIndex, 1.0);
     public static final ControllerSetting<Boolean> RENDER_MINI_PLAYER = createToggleSetting("controllable.options.renderMiniPlayer", Config.CLIENT.client.options.renderMiniPlayer);
     public static final ControllerSetting<Boolean> VIRTUAL_MOUSE = createToggleSetting("controllable.options.virtualMouse", Config.CLIENT.client.options.virtualCursor);
     public static final ControllerSetting<Boolean> CONSOLE_HOTBAR = createToggleSetting("controllable.options.consoleHotbar", Config.CLIENT.client.options.consoleHotbar);

--- a/common/src/main/resources/assets/controllable/lang/en_us.json
+++ b/common/src/main/resources/assets/controllable/lang/en_us.json
@@ -160,6 +160,8 @@
     "controllable.tooltip.more_recipes": "Press %s to View More",
     "framework_config.controllable.client.client.options.autoSelect": "Auto Select",
     "framework_config.controllable.client.client.options.autoSelect.tooltip": "If enabled, controller will be automatically selected on start up or when plugged in",
+    "framework_config.controllable.client.client.options.autoSelectIndex": "Controller Index",
+    "framework_config.controllable.client.client.options.autoSelectIndex.tooltip": "The index of the controller to auto-select (-1 for first available)",
     "framework_config.controllable.client.client.options.consoleHotbar": "Console Hotbar",
     "framework_config.controllable.client.client.options.consoleHotbar.tooltip": "If enabled, hotbar will render closer to the center of the screen like on console.",
     "framework_config.controllable.client.client.options.controllerIcons": "Button Icons",


### PR DESCRIPTION
When Auto-Select is enabled, this lets you use a specific controller (by index in the list) so it is easy to have multiple Minecraft instances with multiple identical controllers each pick a distinct one.

See https://www.reddit.com/r/SteamDeck/comments/1jz3b6t/java_minecraft_14_player_splitscreen_script/ for what I used it for.