### PR TITLE
Fix controller reconnect detection

### DIFF
--- a/common/src/main/java/com/mrcrayfish/controllable/client/input/AdaptiveControllerManager.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/client/input/AdaptiveControllerManager.java
@@ -70,28 +70,47 @@ public abstract class AdaptiveControllerManager
 
     private void updateControllers()
     {
-        if(this.getRawControllerCount() == this.controllers.size())
+        Controller activeController = this.getActiveController();
+        boolean activeControllerOpen = true;
+        if(activeController instanceof MultiController multi)
+        {
+            for(Controller childController : multi.getControllers())
+            {
+                if(!childController.isOpen())
+                {
+                    activeControllerOpen = false;
+                    break;
+                }
+            }
+        }
+        else if(activeController != null)
+        {
+            activeControllerOpen = activeController.isOpen();
+        }
+
+        Map<Number, Pair<Integer, String>> currentControllers = this.createRawControllerMap();
+        if(activeControllerOpen && currentControllers.equals(this.controllers))
             return;
 
-        Map<Number, Pair<Integer, String>> oldControllers = this.controllers;
-        this.controllers = this.createRawControllerMap();
+        Map<Number, Pair<Integer, String>> oldControllers = new HashMap<>(this.controllers);
+        this.controllers = currentControllers;
 
         // Removes all connected from the old map of connected controllers
         oldControllers.keySet().removeIf(this.controllers::containsKey);
 
-        Controller activeController = this.getActiveController();
         if(activeController instanceof MultiController multi)
         {
             // If current controller is a multi, remove controllers that no longer exist
-            for(Controller childController : multi.getControllers())
+            for(Controller childController : new ArrayList<>(multi.getControllers()))
             {
-                if(oldControllers.containsKey(childController.getJid()))
+                if(!childController.isOpen() || oldControllers.containsKey(childController.getJid()) || !this.controllers.containsKey(childController.getJid()))
                 {
                     this.removeActiveController(childController);
                 }
             }
+            activeController = this.getActiveController();
         }
-        else if(activeController != null && oldControllers.containsKey(activeController.getJid()))
+        else if(activeController != null && (!activeControllerOpen || oldControllers.containsKey(activeController.getJid()) || !this.controllers.containsKey(activeController.getJid())))
         {
             this.sendControllerToast(false, activeController);
             this.setActiveController(null);

--- a/common/src/main/java/com/mrcrayfish/controllable/client/input/glfw/GLFWController.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/client/input/glfw/GLFWController.java
@@ -36,8 +36,11 @@ public class GLFWController extends Controller
     @Override
     public void close()
     {
-        this.controller.close();
-        this.controller = null;
+        if(this.controller != null)
+        {
+            this.controller.close();
+            this.controller = null;
+        }
     }
 
     @Override

--- a/common/src/main/java/com/mrcrayfish/controllable/client/input/sdl2/SDL2Controller.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/client/input/sdl2/SDL2Controller.java
@@ -50,6 +50,7 @@ public class SDL2Controller extends Controller
     @Override
     public boolean open()
     {
+        updateControllerState();
         if(this.controller == null)
         {
             this.controller = SDL_GameControllerOpen(this.deviceIndex);
@@ -62,7 +63,7 @@ public class SDL2Controller extends Controller
     @Override
     public void close()
     {
-        if(SDL_GameControllerGetAttached(this.controller))
+        if(this.controller != null)
         {
             SDL_GameControllerClose(this.controller);
             this.controller = null;
@@ -72,7 +73,8 @@ public class SDL2Controller extends Controller
     @Override
     public boolean isOpen()
     {
-        return SDL_GameControllerGetAttached(this.controller);
+        updateControllerState();
+        return this.controller != null && SDL_GameControllerGetAttached(this.controller);
     }
 
     @Override
@@ -138,12 +140,14 @@ public class SDL2Controller extends Controller
     @Override
     public boolean supportsRumble()
     {
-        return SDL_GameControllerHasRumble(this.controller);
+        return this.controller != null && SDL_GameControllerHasRumble(this.controller);
     }
 
     @Override
     protected boolean internalRumble(float lowFrequency, float highFrequency, int timeInMs)
     {
+        if(this.controller == null)
+            return false;
         lowFrequency = Mth.clamp(lowFrequency, 0.0F, 1.0F);
         highFrequency = Mth.clamp(highFrequency, 0.0F, 1.0F);
         return SDL_GameControllerRumble(this.controller, (short) (0xFFFF * lowFrequency), (short) (0xFFFF * highFrequency), timeInMs) == 0;
@@ -216,6 +220,12 @@ public class SDL2Controller extends Controller
         if(SDL_GameControllerSetSensorEnabled(this.controller, SDL_SENSOR_GYRO, true) != 0)
             return;
         this.gyro = true;
+    }
+
+    private static void updateControllerState()
+    {
+        SDL_GameControllerUpdate();
+        SDL_JoystickUpdate();
     }
 
     @Override

--- a/common/src/main/java/com/mrcrayfish/controllable/client/input/sdl2/SDL2ControllerManager.java
+++ b/common/src/main/java/com/mrcrayfish/controllable/client/input/sdl2/SDL2ControllerManager.java
@@ -38,6 +38,7 @@ import static com.mrcrayfish.controllable_sdl.api.gamecontroller.SdlGamecontroll
 import static com.mrcrayfish.controllable_sdl.api.hints.SdlHints.SDL_SetHint;
 import static com.mrcrayfish.controllable_sdl.api.hints.SdlHintsConst.*;
 import static com.mrcrayfish.controllable_sdl.api.joystick.SdlJoystick.SDL_JoystickGetDeviceInstanceID;
+import static com.mrcrayfish.controllable_sdl.api.joystick.SdlJoystick.SDL_JoystickUpdate;
 import static com.mrcrayfish.controllable_sdl.api.joystick.SdlJoystick.SDL_NumJoysticks;
 import static com.mrcrayfish.controllable_sdl.api.rwops.SdlRWops.SDL_RWFromConstMem;
 
@@ -104,6 +105,7 @@ public class SDL2ControllerManager extends AdaptiveControllerManager
     @Override
     protected int getRawControllerCount()
     {
+        updateControllerState();
         int controllerCount = 0;
         int joysticksCount = SDL_NumJoysticks();
         for(int deviceIndex = 0; deviceIndex < joysticksCount; deviceIndex++)
@@ -119,6 +121,7 @@ public class SDL2ControllerManager extends AdaptiveControllerManager
     @Override
     protected Map<Number, Pair<Integer, String>> createRawControllerMap()
     {
+        updateControllerState();
         Map<Number, Pair<Integer, String>> controllers = new HashMap<>();
         int joysticksCount = SDL_NumJoysticks();
         for(int deviceIndex = 0; deviceIndex < joysticksCount; deviceIndex++)
@@ -137,11 +140,13 @@ public class SDL2ControllerManager extends AdaptiveControllerManager
     @Nullable
     public Controller connectToBestGameController()
     {
+        updateControllerState();
+        int joysticksCount = SDL_NumJoysticks();
         List<DeviceInfo> lastDevices = this.getLastDevices();
         if(!lastDevices.isEmpty())
         {
             List<SDL2Controller> selectedControllers = new ArrayList<>();
-            List<SDL2Controller> availableControllers = IntStream.range(0, SDL_NumJoysticks())
+            List<SDL2Controller> availableControllers = IntStream.range(0, joysticksCount)
                 .filter(SdlGamecontroller::SDL_IsGameController)
                 .mapToObj(SDL2Controller::new)
                 .collect(Collectors.toCollection(ArrayList::new));
@@ -169,7 +174,6 @@ public class SDL2ControllerManager extends AdaptiveControllerManager
             }
         }
 
-        int joysticksCount = SDL_NumJoysticks();
         for(int deviceIndex = 0; deviceIndex < joysticksCount; deviceIndex++)
         {
             if(SDL_IsGameController(deviceIndex))
@@ -182,6 +186,12 @@ public class SDL2ControllerManager extends AdaptiveControllerManager
             }
         }
         return null;
+    }
+
+    private static void updateControllerState()
+    {
+        SDL_GameControllerUpdate();
+        SDL_JoystickUpdate();
     }
 
     @Override


### PR DESCRIPTION
Fixes #623.

## Summary

This updates controller reconnect handling so a controller sleep/wake cycle is detected even when the raw controller count stays the same.

The controller manager now compares the full controller map and validates whether the currently selected controller is still open before deciding there is nothing to update. SDL and GLFW controllers also tolerate repeated close/is-open checks without dereferencing a null native handle.

For SDL, joystick and game controller state is refreshed before opening, attachment checks, and device enumeration. This helps SDL observe Bluetooth controller sleep/wake transitions before Controllable decides whether to reconnect or auto-select a controller.

## Validation

- `git diff --check`
- Manual test with a DualSense controller on Windows/Bluetooth in a Forge 1.20.1 modpack using the equivalent patched behavior: after the controller slept and woke, Controllable detected it again without restarting Minecraft.

Local Gradle compilation could not complete in this checkout because required MrCrayfish artifacts (`framework-*`, `controllable-sdl`) were not resolvable from the configured public repositories, and the loader-excluded compile path hit local Java toolchain provisioning for Java 25.
